### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/buienalarm/api.py
+++ b/custom_components/buienalarm/api.py
@@ -33,7 +33,7 @@ class BuienalarmApiClient:
         self.session = session
         self.hass = hass
         self.notification_id = None
-        _LOGGER.debug("7latitude = %s, longitude = %s", self.latitude, self.longitude)
+        _LOGGER.debug("BuienalarmApiClient initialized with provided coordinates.")
 
     async def old_fetch_data(self):
         """Fetch Buienalarm data."""


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/Buienalarm/security/code-scanning/1](https://github.com/HiDiHo01/Buienalarm/security/code-scanning/1)

To fix the problem, we should avoid logging sensitive information such as latitude and longitude in clear text. Instead, we can log a generic message that does not include the sensitive data. This way, we maintain the logging functionality for debugging purposes without exposing sensitive information.

- Replace the logging statement on line 36 in `api.py` to remove the sensitive data.
- Ensure that the new logging statement provides enough context for debugging without including sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
