### PR TITLE
Fix code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/buienalarm/api.py
+++ b/custom_components/buienalarm/api.py
@@ -158,7 +158,7 @@ class BuienalarmApiClient:
         _LOGGER.debug("async_fetch_daily_forecast_data BuienalarmApiClient data")
         try:
             url = API_ENDPOINT.format(self.latitude, self.longitude)
-            _LOGGER.debug("8latitude = %s, longitude = %s", self.latitude, self.longitude)
+            _LOGGER.debug("Fetching data from API endpoint with provided coordinates")
             async with async_timeout.timeout(API_TIMEOUT):
                 response = await self.session.get(url)
                 response.raise_for_status()


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/Buienalarm/security/code-scanning/6](https://github.com/HiDiHo01/Buienalarm/security/code-scanning/6)

To fix the problem, we should avoid logging sensitive information such as latitude and longitude coordinates. Instead, we can log a generic message that does not include the sensitive data. This way, we maintain the ability to debug without exposing sensitive information.

- Replace the debug log statement on line 161 with a generic message that does not include latitude and longitude.
- Ensure that no sensitive information is logged in other parts of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
