### PR TITLE
Fix code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/buienalarm/api.py
+++ b/custom_components/buienalarm/api.py
@@ -133,8 +133,7 @@ class BuienalarmApiClient:
     async def _handle_error_logging(self, exception, url=None):
         if url:
             _LOGGER.error(
-                "Error fetching information from %s - %s",
-                url,
+                "Error fetching information from the API - %s",
                 exception,
             )
         else:


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/Buienalarm/security/code-scanning/4](https://github.com/HiDiHo01/Buienalarm/security/code-scanning/4)

To fix the problem, we should avoid logging sensitive information such as latitude and longitude. Instead, we can log a generic message that does not include the sensitive data. This can be achieved by modifying the logging statements to exclude the `url` variable.

- In general terms, we should replace the logging of sensitive data with a more generic message.
- Specifically, we will modify the `_handle_error_logging` method to log a generic error message without including the `url`.
- The changes will be made in the `custom_components/buienalarm/api.py` file.
- No additional methods, imports, or definitions are needed to implement these changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
