### PR TITLE
Fix code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/custom_components/buienalarm/api.py
+++ b/custom_components/buienalarm/api.py
@@ -91,8 +91,7 @@ class BuienalarmApiClient:
                     raise ApiError("Invalid data type or structure in JSON response")
         except asyncio.TimeoutError as exception:
             _LOGGER.error(
-                "Timeout error fetching information from %s - %s",
-                url,
+                "Timeout error fetching information from the API - %s",
                 exception,
             )
         except (aiohttp.ClientError, socket.gaierror) as exception:


### PR DESCRIPTION
Fixes [https://github.com/HiDiHo01/Buienalarm/security/code-scanning/3](https://github.com/HiDiHo01/Buienalarm/security/code-scanning/3)

To fix the problem, we should avoid logging sensitive information such as latitude and longitude. Instead, we can log a generic message or mask the sensitive parts of the data. The best way to fix this without changing existing functionality is to remove or modify the logging statements that include sensitive data.

Specifically, we need to:
1. Remove or modify the logging statement on line 95 that logs the `url` containing latitude and longitude.
2. Ensure that other logging statements do not inadvertently log sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
