### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/buienalarm/__init__.py
+++ b/custom_components/buienalarm/__init__.py
@@ -3,7 +3,8 @@ import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.core_config import Config
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType


### PR DESCRIPTION
Config was used from buienalarm, this is a deprecated alias which will be removed in HA Core 2025.11. Use homeassistant.core_config.Config instead